### PR TITLE
convert hitman bio from  array to string

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ end
     method: methods.sample,
     name: Faker::TvShows::RuPaul.queen,
     location: Faker::Address.community,
-    bio: Faker::Books::Lovecraft.sentences
+    bio: Faker::Books::Lovecraft.sentences.join(' ')
   ).save
 end
 


### PR DESCRIPTION
Before:

```ruby
Faker::Books::Lovecraft.sentences
=> 
["Dank gambrel ululate accursed.",                                                        
 "Antediluvian ululate cat stench.",                                                      
 "Cyclopean iridescence dank madness fungus swarthy gibbous."] 
```

After:

```ruby
"Foetid unmentionable abnormal shunned.Daemoniac gambrel effulgence blasphemous.Nameless effulgence accursed." 
```

Note: This change requires you to drop & recreate the dev database as the previous seeder should've populated the database with misformed strings (array of strings). E.g.:

```ruby
rails db:drop
rails db:create
rails db:migrate
rails db:seed
```
